### PR TITLE
Making call to ICollector.Collect asynchronous

### DIFF
--- a/src/LogAnalytics.Extensions.Logging/Provider/LogAnalyticsLogger.cs
+++ b/src/LogAnalytics.Extensions.Logging/Provider/LogAnalyticsLogger.cs
@@ -1,6 +1,8 @@
 ﻿using HTTPDataCollectorAPI;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace LogAnalytics.Extensions.Logging
 {
@@ -58,7 +60,9 @@ namespace LogAnalytics.Extensions.Logging
 			{
 				message += $"{Environment.NewLine}{Environment.NewLine}{exception.ToString()}";
 			}
-			_collector.Collect($"{_environmentName}", new LogEvent() { CategoryName=_categoryName, LogLevel=logLevel.ToString(), Message=message }).Wait();
+			
+			_collector.Collect($"{_environmentName}", new LogEvent() { CategoryName=_categoryName, LogLevel=logLevel.ToString(), Message=message })
+				.ContinueWith(e => Debug.WriteLine(e.Exception), TaskContinuationOptions.OnlyOnFaulted);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This change does an async call to ICollector.Collect, but still catches any exceptions.
Reason: because the logging API in ASP.NET Core is synchonious, you shouldn't wait for the
results from the log-call to Azure Log Analytics, as this slows down
your application.